### PR TITLE
Add new feature API new method retrieving all known PDB entries

### DIFF
--- a/app/controllers/pssm_json_controller.rb
+++ b/app/controllers/pssm_json_controller.rb
@@ -115,4 +115,22 @@ class PssmJsonController < ApplicationController
     end
     return mapping
   end
+
+  def pssm_list_ids
+    initial = params[:initial]
+    if initial =~ /\A\d+\Z/
+      query = "SELECT pdb,chain FROM pdbChainIterStatus WHERE status_uniref100=0 AND pdb LIKE '#{initial}___' GROUP BY pdb,chain;"
+    else
+      return render :json => {:error => "Bad or missing parameter", :msg => "Please provide PDB Id initial as parameter, e.g. http://3dcons.cnb.csic.es/pssm_json/list/1"}, :status => 400
+    end
+
+    pdb_list = []
+    db = SQLite3::Database.new PDB_PSSM_DB
+    db.execute(query) do |r|
+      pdb = {"pdbId" => r[0], "chainId" => r[1]}
+      pdb_list.push(pdb)
+    end
+    return render :json => {"KnownPdbIds": pdb_list}
+  end
+
 end

--- a/app/views/web/help.html.haml
+++ b/app/views/web/help.html.haml
@@ -29,6 +29,17 @@
 
   %div{:class=>"section", :id=>"#restful"}RESTFUL SERVICE
   %div{:class=>"section_text"}
+
+    *** NEW FEATURE ***
+    As per user request, we have added a new method to enable retrieving all known PDB Ids in JSON format
+    %br
+    %b http://3dcons.cnb.csic.es/pssm_json/list/&lt;PDB_initial#&gt;
+    %br
+    E.g. 
+    %a{:href=>"http://3dcons.cnb.csic.es/pssm_json/list/1", :target=>"_blank"}http://3dcons.cnb.csic.es/pssm_json/list/1
+    %br
+    *** ***
+    %br
     The RESTful service can be accessed via http request codifying the URL as
     %br
     %b http://3dcons.cnb.csic.es/pssm_json/&lt;PDB&gt;


### PR DESCRIPTION
A new method http://3dcons.cnb.csic.es/pssm_json/list/1 is added to the API, so users can request a list of all the known PDB entries. Due to its size, list is queried by PDB-ID initial (the numerical value 1-9).